### PR TITLE
Add org-fragtog-preview-delay

### DIFF
--- a/org-fragtog.el
+++ b/org-fragtog.el
@@ -36,6 +36,16 @@
 
 (require 'org)
 
+(defgroup org-fragtog nil
+  "Automatically toggle org-mode latex fragment previews as the
+cursor enters and exits them."
+  :group 'org)
+
+(defcustom org-fragtog-preview-delay
+  .0
+  "The idle delay in seconds until preview starts automatically."
+  :type 'number)
+
 ;;;###autoload
 (define-minor-mode org-fragtog-mode
   "Toggle Org Latex Fragment Autotoggle Mode, a minor mode that automatically
@@ -104,7 +114,9 @@ If there is none, return nil."
   (save-excursion
     (goto-char (car
                 (org-fragtog--frag-pos frag)))
-    (org-latex-preview)))
+    (if (> org-fragtog-preview-delay 0)
+        (run-with-idle-timer org-fragtog-preview-delay nil #'org-latex-preview)
+      (org-latex-preview))))
 
 (defun org-fragtog--disable-frag (frag)
   "Disable the org latex fragment preview for the fragment FRAG."


### PR DESCRIPTION
When cursor is moving very fast across equations in different
lines/columns, `org-latex-preview` is triggered very frequently and
instantly. This commit adds a custom variable
`org-fragtog-preview-delay` to allow preview to be shown when Emacs is
idle.