### PR TITLE
Add org-fragtog-preview-delay

### DIFF
--- a/org-fragtog.el
+++ b/org-fragtog.el
@@ -119,7 +119,8 @@ It handles toggling fragments depending on whether the cursor entered or exited 
             (setq org-fragtog--timer (run-with-idle-timer org-fragtog-preview-delay
                                                           nil
                                                           #'org-fragtog--disable-frag
-                                                          cursor-frag))
+                                                          cursor-frag
+                                                          t))
           (org-fragtog--disable-frag cursor-frag))))))
 
 (defun org-fragtog--cursor-frag ()
@@ -164,15 +165,24 @@ return nil."
                 (org-fragtog--frag-pos frag)))
     (org-latex-preview)))
 
-(defun org-fragtog--disable-frag (frag)
+(defun org-fragtog--disable-frag (frag &optional renew)
   "Disable the Org LaTeX fragment preview for the fragment FRAG."
-  (let
-      ((pos (org-fragtog--frag-pos frag)))
-    (org-clear-latex-preview (car pos)
-                             (cdr pos))
-    ;; Expire timer
-    (when org-fragtog--timer
-      (setq org-fragtog--timer nil))))
+
+  ;; Renew frag at point in case point was adjusted
+  ;; See Emacs Lisp manual, 21.6 Adjusting Point After Commands
+  (when renew
+    (setq frag (org-fragtog--cursor-frag))
+    (setq org-fragtog--prev-frag frag))
+
+  ;; There may be nothing at the adjusted point
+  (when frag
+    (let
+        ((pos (org-fragtog--frag-pos frag)))
+      (org-clear-latex-preview (car pos)
+                               (cdr pos))
+      ;; Expire timer
+      (when org-fragtog--timer
+        (setq org-fragtog--timer nil)))))
 
 (defun org-fragtog--frag-pos (frag)
   "Get the position of the fragment FRAG.

--- a/org-fragtog.el
+++ b/org-fragtog.el
@@ -115,10 +115,12 @@ It handles toggling fragments depending on whether the cursor entered or exited 
         (setq org-fragtog--timer nil))
       ;; Disable fragment if cursor entered it
       (when cursor-frag
-        (setq org-fragtog--timer (run-with-idle-timer org-fragtog-preview-delay
-                                                      nil
-                                                      #'org-fragtog--disable-frag
-                                                      cursor-frag))))))
+        (if (> org-fragtog-preview-delay 0)
+            (setq org-fragtog--timer (run-with-idle-timer org-fragtog-preview-delay
+                                                          nil
+                                                          #'org-fragtog--disable-frag
+                                                          cursor-frag))
+          (org-fragtog--disable-frag cursor-frag))))))
 
 (defun org-fragtog--cursor-frag ()
   "Return the fragment currently surrounding the cursor.
@@ -169,7 +171,8 @@ return nil."
     (org-clear-latex-preview (car pos)
                              (cdr pos))
     ;; Expire timer
-    (setq org-fragtog--timer nil)))
+    (when org-fragtog--timer
+      (setq org-fragtog--timer nil))))
 
 (defun org-fragtog--frag-pos (frag)
   "Get the position of the fragment FRAG.

--- a/org-fragtog.el
+++ b/org-fragtog.el
@@ -109,7 +109,9 @@ It handles toggling fragments depending on whether the cursor entered or exited 
       ;; Enable fragment if cursor left it after a timed disable
       ;; and the fragment still exists
       (when (and frag-at-prev-pos
-                 (not org-fragtog--timer))
+                 (not (overlays-in
+                       (car (org-fragtog--frag-pos frag-at-prev-pos))
+                       (cdr (org-fragtog--frag-pos frag-at-prev-pos)))))
         (org-fragtog--enable-frag frag-at-prev-pos))
       ;; Cancel and expire timer
       (when org-fragtog--timer

--- a/org-fragtog.el
+++ b/org-fragtog.el
@@ -50,6 +50,11 @@ For example, adding `org-at-table-p' will ignore fragments inside tables."
              org-at-block-p
              org-at-heading-p))
 
+(defcustom org-fragtog-preview-delay 0.0
+  "Seconds of delay before LaTeX preview."
+  :group 'org-fragtog
+  :type 'number)
+
 ;;;###autoload
 (define-minor-mode org-fragtog-mode
   "A minor mode that automatically toggles Org mode LaTeX fragment previews.
@@ -68,6 +73,9 @@ and re-enabled when the cursor leaves."
 (defvar-local org-fragtog--prev-frag nil
   "Previous fragment that surrounded the cursor, or nil if the cursor was not
 on a fragment. This is used to track when the cursor leaves a fragment.")
+
+(defvar-local org-fragtog--timer nil
+  "Current active timer.")
 
 (defun org-fragtog--post-cmd ()
   "This function is executed by `post-command-hook' in `org-fragtog-mode'.
@@ -101,9 +109,16 @@ It handles toggling fragments depending on whether the cursor entered or exited 
       ;; Enable fragment if cursor left it and it still exists
       (when frag-at-prev-pos
         (org-fragtog--enable-frag frag-at-prev-pos))
+      ;; Cancel and expire timer
+      (when org-fragtog--timer
+        (cancel-timer org-fragtog--timer)
+        (setq org-fragtog--timer nil))
       ;; Disable fragment if cursor entered it
       (when cursor-frag
-        (org-fragtog--disable-frag cursor-frag)))))
+        (setq org-fragtog--timer (run-with-idle-timer org-fragtog-preview-delay
+                                                      nil
+                                                      #'org-fragtog--disable-frag
+                                                      cursor-frag))))))
 
 (defun org-fragtog--cursor-frag ()
   "Return the fragment currently surrounding the cursor.
@@ -152,7 +167,9 @@ return nil."
   (let
       ((pos (org-fragtog--frag-pos frag)))
     (org-clear-latex-preview (car pos)
-                             (cdr pos))))
+                             (cdr pos))
+    ;; Expire timer
+    (setq org-fragtog--timer nil)))
 
 (defun org-fragtog--frag-pos (frag)
   "Get the position of the fragment FRAG.

--- a/org-fragtog.el
+++ b/org-fragtog.el
@@ -106,8 +106,10 @@ It handles toggling fragments depending on whether the cursor entered or exited 
     (when frag-changed
       ;; Current fragment is the new previous
       (setq org-fragtog--prev-frag cursor-frag)
-      ;; Enable fragment if cursor left it and it still exists
-      (when frag-at-prev-pos
+      ;; Enable fragment if cursor left it after a timed disable
+      ;; and the fragment still exists
+      (when (and frag-at-prev-pos
+                 (not org-fragtog--timer))
         (org-fragtog--enable-frag frag-at-prev-pos))
       ;; Cancel and expire timer
       (when org-fragtog--timer

--- a/org-fragtog.el
+++ b/org-fragtog.el
@@ -176,17 +176,15 @@ return nil."
   ;; See Emacs Lisp manual, 21.6 Adjusting Point After Commands
   (when renew
     (setq frag (org-fragtog--cursor-frag))
-    (setq org-fragtog--prev-frag frag))
+    (setq org-fragtog--prev-frag frag)
+    (setq org-fragtog--timer nil))
 
   ;; There may be nothing at the adjusted point
   (when frag
     (let
         ((pos (org-fragtog--frag-pos frag)))
       (org-clear-latex-preview (car pos)
-                               (cdr pos))
-      ;; Expire timer
-      (when org-fragtog--timer
-        (setq org-fragtog--timer nil)))))
+                               (cdr pos)))))
 
 (defun org-fragtog--frag-pos (frag)
   "Get the position of the fragment FRAG.


### PR DESCRIPTION
**Purpose**
Enable delayed preview so that moving through LaTeX fragments
does not toggle them unless the cursor stops and Emacs is idle.

**Testing**
Tested by creating multiple LaTeX fragments and moving through them with different `org-fragtog-preview-delay` values. Everything works as expected. If the cursor leaves a fragment before the timer fired, the timer is cancelled  and `org-fragtog--enable-frag` is not called.

There is one bug related to the way `post-cmd` works. When the cursor moves through an *untoggled* fragment from left to right and stops at the next point after the fragment, `org-fragtog--cursor-frag` still returns the fragment (despite adjusting by `:post-blank` as a precaution).

```
This $LaTeX$ fragment
            ^
            |       
     this point considered part of the fragment
```
This means that the timer is not cancelled if the user stops at that point and the fragment is disabled. This does not happen when the cursor moves from right to left or when the cursor moves through a fragment that has been disabled already.

**Further comments**
I am working on the same feature in [org-appear](https://github.com/awth13/org-appear) and decided I might as well contribute my solution to `org-fragtog`. The bug described above does not affect `org-fragtog` as much as it does `org-appear` -- in the latter, it can lead to the next immediately adjacent fragment not being toggled at all. I am looking for a solution but so far no ideas. (EDIT: I believe that a solution for this will not affect how the timer creation/cancellation is implemented).