### PR TITLE
Obtain new bounds of previous fragment when enabling

### DIFF
--- a/org-fragtog.el
+++ b/org-fragtog.el
@@ -87,20 +87,20 @@ It handles toggling fragments depending on whether the cursor entered or exited 
                    prev-frag-start-pos))
        ;; The current fragment changed
        (frag-changed (not frag-same))
-       ;; The fragment at prev-frag still exists.
+       ;; The fragment at position of previous fragment.
        ;; This can be nil when for example $foo$ is edited to become $foo $.
-       (prev-frag-still-exists (and prev-frag-start-pos
-                                    (save-excursion
-                                      (goto-char prev-frag-start-pos)
-                                      (org-fragtog--cursor-frag)))))
+       (frag-at-prev-pos (and prev-frag-start-pos
+                              (save-excursion
+                                (goto-char prev-frag-start-pos)
+                                (org-fragtog--cursor-frag)))))
 
     ;; Only do anything if the current fragment changed
     (when frag-changed
       ;; Current fragment is the new previous
       (setq org-fragtog--prev-frag cursor-frag)
       ;; Enable fragment if cursor left it and it still exists
-      (when prev-frag-still-exists
-        (org-fragtog--enable-frag prev-frag))
+      (when frag-at-prev-pos
+        (org-fragtog--enable-frag frag-at-prev-pos))
       ;; Disable fragment if cursor entered it
       (when cursor-frag
         (org-fragtog--disable-frag cursor-frag)))))


### PR DESCRIPTION
### Rationale
Working on #25, I discovered another issue with the way `prev-frag` is enabled upon leaving. When an active (disabled) fragment is edited, its bounds change; `org-fragtog`, however, still uses the old bounds (stored in `prev-frag`) when the cursor leaves and the fragment is enabled. This is not an issue most of the time since `org-latex-preview` and `org-clear-latex-preview` are smart with how they treat toggled regions. Under certain conditions, however, this may cause another fragment to be incorrectly disabled. Here's an example:
```
$This LaTeX fragment$

$Next LaTeX fragment$
```
If we delete the word "LaTeX" in this fragment and move the cursor to the empty line that follows, the next LaTeX fragment will be disabled.

### Testing
The next LaTeX fragment is no longer disabled in the situation described above.

### Comments
I had and fixed the same issue in `org-appear` some time ago but didn't think it also affects `org-fragtog`. Turns out `org-clear-latex-preview` is not smart enough. I decided not to implement this fix within #25 because it's an unrelated issue.